### PR TITLE
issue #120 관련. yg-amazon-exp branch 정리를 위한 cherry-picking

### DIFF
--- a/BLEEPlib/src/mainmodules/EstimateRTTModule.cpp
+++ b/BLEEPlib/src/mainmodules/EstimateRTTModule.cpp
@@ -607,6 +607,10 @@ bool EstimateRTTModule::MulticastMessage(std::shared_ptr<Message> message) {
     int sentOut = 0;
     for (int i : idxs) {
         if (message->GetSource().GetId() != dests[i].GetId() && sentOut < fanOut) {
+            // check whether there exists a data socket for the destination peer
+            if (!peerManager.HasEstablishedDataSocket(dests[i]))
+                continue;
+
             // get datasocket
             int socketFD = peerManager.GetConnectedSocketFD(dests[i]);
             std::shared_ptr<RTTModule_DataSocket> dataSocket = socketManager.GetDataSocket(socketFD);
@@ -667,6 +671,10 @@ bool EstimateRTTModule::ForwardMessage(std::shared_ptr<RTTModule_MessageHeader> 
     int sentOut = 0;
     for (int i : idxs) {
         if (message->GetSource().GetId() != dests[i].GetId() && sentOut < fanOut){
+            // check whether there exists a data socket for the destination peer
+            if (!peerManager.HasEstablishedDataSocket(dests[i]))
+                continue;
+
             // get datasocket
             int socketFD = peerManager.GetConnectedSocketFD(dests[i]);
             std::shared_ptr<RTTModule_DataSocket> dataSocket = socketManager.GetDataSocket(socketFD);


### PR DESCRIPTION
#120 에 나온것과 같이, stale branch인 yg-amazon-exp를 정리하는 과정에서, 하나의 commit만을 히스토리로 남기기위해 master로 cherry-picking하였다.

해당 커밋은 BLEEP lib로 PoW node를 만들어 아마존에서 동작시킬때, 예기치 않은 오류를 방지하기 위한 fix이다.