### PR TITLE
hotfix - Remove monero, eos from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "external/go-ethereum/1.9.1dev"]
 	path = external/go-ethereum/1.9.1dev
 	url = https://github.com/kaistshadow/go-ethereum
-[submodule "external/monero/dev_0.16.0"]
-	path = external/monero/dev_0.16.0
-	url = https://github.com/kaistshadow/monero.git
 [submodule "external/zcash/zcash"]
 	path = external/zcash/zcash
 	url = https://github.com/kaistshadow/zcash.git


### PR DESCRIPTION
이전 PR #136 에서 submodule 지워진 정보가 .gitmodules에는 남아있는 문제가 있어서, 이를 수정하는 patch를 하고자 합니다.
