### PR TITLE
Refactoring regression tests for bitcoin (tests/regtest/1_bitcoin)

### DIFF
--- a/tests/regtest/1_bitcoin/10_initialCoin/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/10_initialCoin/CMakeLists.txt
@@ -17,13 +17,15 @@ add_custom_target(bitcoin_initialCoin_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(bitcoin_initialCoin_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(bitcoin_initialCoin_test_prepare_plugin ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_dependencies(bitcoin_initialCoin_test_prepare2 Bitcoin_0_19_1dev::Plugin)
-
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME bitcoin_initialCoin_test
   COMMAND python3 initialCoin.py

--- a/tests/regtest/1_bitcoin/2_shadow/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/2_shadow/CMakeLists.txt
@@ -17,14 +17,17 @@ add_custom_target(shadow_xmlGenerator_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(shadow_xmlGenerator_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR}
-  )
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 
-add_custom_target(shadow_xmlGenerator_test_prepare3 ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_dependencies(shadow_xmlGenerator_test_prepare2 Bitcoin_0_19_1dev::Plugin)
 
 add_test(NAME shadow_log_test
   COMMAND python3 shadowCheck.py

--- a/tests/regtest/1_bitcoin/3_blockchainApplication/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/3_blockchainApplication/CMakeLists.txt
@@ -17,13 +17,15 @@ add_custom_target(bitcoinApplication_shadow_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(bitcoinApplication_shadow_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_dependencies(bitcoinApplication_shadow_test_prepare2 Bitcoin_0_19_1dev::Plugin)
-
-add_custom_target(bitcoinApplication_shadow_test_prepare3 ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp  -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME bitcoinApplication_shadow_test
   COMMAND python3 bitcoinApplication.py

--- a/tests/regtest/1_bitcoin/4_difficulty/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/4_difficulty/CMakeLists.txt
@@ -17,13 +17,16 @@ add_custom_target(shadow_bitcoin_difficulty_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(shadow_bitcoin_difficulty_test2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(shadow_bitcoin_difficulty_rpc ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_dependencies(shadow_bitcoin_difficulty_test2 Bitcoin_0_19_1dev::Plugin)
 add_test(NAME shadow_bitcoin_difficulty_test
   COMMAND python3 difficulty.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/regtest/1_bitcoin/5_walletAddress/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/5_walletAddress/CMakeLists.txt
@@ -17,12 +17,15 @@ add_custom_target(bitcoinWallet_shadow_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(bitcoinWallet_shadow_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(shadow-bitcoin-dev-one-node-mine-plugin_wallet ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_dependencies(bitcoinWallet_shadow_test_prepare2 Bitcoin_0_19_1dev::Plugin)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME bitcoinWallet_shadow_test
   COMMAND python3 walletAddress.py

--- a/tests/regtest/1_bitcoin/6_mining/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/6_mining/CMakeLists.txt
@@ -17,11 +17,13 @@ add_custom_target(bitcoinMining_shadow_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(bitcoinMining_shadow_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_dependencies(bitcoinMining_shadow_test_prepare2 Bitcoin_0_19_1dev::Plugin)
-
-add_custom_target(bitcoinMining_shadow_test_prepare3 ALL
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
         COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/regtest/1_bitcoin/7_mainchain/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/7_mainchain/CMakeLists.txt
@@ -17,13 +17,16 @@ add_custom_target(bitcoinMainchain_shadow_test_prepare ALL
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_custom_target(bitcoinMainchain_shadow_test_prepare2 ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(bitcoinMainchain_shadow_plugin ALL
-  COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-  
-add_dependencies(bitcoinMainchain_shadow_test_prepare2 Bitcoin_0_19_1dev::Plugin)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.cpp
+        COMMAND gcc -o rpc.so rpc.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_test(NAME bitcoinMainchain_shadow_test
   COMMAND python3 mainchaintest.py
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/tests/regtest/1_bitcoin/8_transaction/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/8_transaction/CMakeLists.txt
@@ -17,15 +17,20 @@ add_custom_target(shadow-bitcoin-transaction-prepare ALL
   COMMAND mkdir -p data/bcdnode0
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO : unresolved dependency problem during full build is still remaining.
 add_custom_target(shadow-bitcoin-transaction-copy-plugin ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
-add_dependencies(shadow-bitcoin-transaction-copy-plugin Bitcoin_0_19_1dev::Plugin)
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/transaction.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(shadow-bitcoin-dev-one-node-mine-plugin_tx ALL
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/transaction.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/one_node_setmine.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/transaction.cpp
         COMMAND gcc -o rpc.so one_node_setmine.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
         COMMAND gcc -o transaction.so transaction.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_test(NAME shadow-bitcoin-transaction-test
   COMMAND python3 transaction.py

--- a/tests/regtest/1_bitcoin/9_transactionCheck/CMakeLists.txt
+++ b/tests/regtest/1_bitcoin/9_transactionCheck/CMakeLists.txt
@@ -17,12 +17,17 @@ add_custom_target(shadow-bitcoin-transaction_count-prepare ALL
   COMMAND mkdir -p data/bcdnode0
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TODO : unresolved dependency problem during full build is still remaining.
 add_custom_target(shadow-bitcoin-transaction_count-copy-plugin ALL
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
-add_dependencies(shadow-bitcoin-transaction_count-copy-plugin Bitcoin_0_19_1dev::Plugin)
+        DEPENDS Bitcoin_0_19_1dev::Plugin
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/transaction.so
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Bitcoin_0_19_1dev::Plugin> ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_custom_target(shadow-bitcoin-dev-one-node-mine-plugin_tx_check ALL
+add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/rpc.so
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/transaction.so
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/one_node_setmine.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../libraries/rpc_client.cpp
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/transaction.cpp
         COMMAND gcc -o rpc.so one_node_setmine.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g -std=c99
         COMMAND gcc -o transaction.so transaction.cpp ../libraries/rpc_client.cpp -ljsoncpp -lcurl -lssl -shared -fPIC -Wl,-rpath=${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -L${CMAKE_CURRENT_SOURCE_DIR}/../../../../Install/curl_7.70.0/lib -g
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This PR is related to issue #237

The following modifications are applied for `tests/regtest/1_bitcoin`.
- Use add_custom_command instead of add_custom_target for the compilation of the test objects.
- `add_custom_command` is only executed when OUTPUT is not generated or there's modification of source code
