### PR TITLE
Remove regtest function not needed in 14_regtest

### DIFF
--- a/testlibs/test_modules.py
+++ b/testlibs/test_modules.py
@@ -600,7 +600,7 @@ def monitor_connection_test(plugin_output_files, abs_path, node_count):
     sys.exit(1)
 
 # --------------------------------------------------------------------------------------------------------------
-#                                       Regression test-14-1 - monitor node block propagation test
+#                                       Regression test-14 monitor node block propagation test
 # --------------------------------------------------------------------------------------------------------------
 # Monitor 노드는 비트코인 노드로 부터 블록을 전파받음. 이렇게 전파 받은 블록의 해시 값들과,
 # 비트코인 실행 결과 로그 값에 기록된 블록 해시 값들을 비교하여, Monitor 노드가 제대로 전파를 받았나 확인을 하는 테스트
@@ -636,18 +636,6 @@ def Mointor_block_propagation_test(plugin_output_files, node_count, target_path)
                 sys.exit(1)
     print("Success Monitor block propagation test ... ")
     sys.exit(0)
-
-# --------------------------------------------------------------------------------------------------------------
-#                                       Regression test-14-2 - TxGenerator Tx propagation test
-# --------------------------------------------------------------------------------------------------------------
-def clinet_block_propagation_test(plugin_output_files, node_count):
-    block_hash_list = utils.get_block_hash_list(plugin_output_files, node_count)
-    for i in range(len(plugin_output_files)):
-        block_hash_list_copy = []
-        result = plugin_output_files[i].find("bcdnode")
-        if result != -1:
-            utils.compare_hash_values(block_hash_list, utils.overlap_blockHash(plugin_output_files[i]))
-
 
 # --------------------------------------------------------------------------------------------------------------
 #                                       Regression test-15 - TxGenerator connection test

--- a/testlibs/utils.py
+++ b/testlibs/utils.py
@@ -329,26 +329,6 @@ def filter_block_hash(plugin_output_files, node_count):
     
     return node_list
 
-def get_block_hash_list(plugin_output_files, node_count):
-    
-    block_hash_list = []
-    for i in range(0,len(plugin_output_files)):
-        result = plugin_output_files[i].find("monitor")
-        if result != -1:
-            f = open(plugin_output_files[i], "r")
-            while True:
-                line = f.readline()
-                if not line: break
-                result = line.find("[INV] MSGBLOCK : blockhash")
-                if result != -1:
-                    input_data = line.split("=")[1].split(" ")[1].strip()
-                    if input_data in block_hash_list:
-                        continue
-                    else:
-                        block_hash_list.append(input_data)
-            f.close()
-    return block_hash_list
-
 # Updatetip을 기준으로 선별된 블록들 중에 중복된 블록 제거
 def overlap_blockHash(bitcoind_log):
     hash_list = []
@@ -365,11 +345,3 @@ def overlap_blockHash(bitcoind_log):
                 hash_list.append(input_data)
     f.close()
     return hash_list
-
-def compare_hash_values(param_log1, param_log2):
-    for i in range(len(param_log1)):
-        if param_log1[i] in param_log2:
-            continue
-        else:
-            print("Fail block propagations test ... ")
-            sys.exit(1)

--- a/tests/regtest/1_bitcoin/14_propagationBlock/block_propagation.py
+++ b/tests/regtest/1_bitcoin/14_propagationBlock/block_propagation.py
@@ -52,9 +52,6 @@ def main():
     # # Start propagationBlock test
     test_modules.Mointor_block_propagation_test(simulation_output_file, len(IP_list)-2, path)
 
-    # start comparing block hash values
-    test_modules.clinet_block_propagation_test(simulation_output_file, len(IP_list))
-
 if __name__ == '__main__':
     main()
     


### PR DESCRIPTION
14번 regtest는 블록 전파가 모니터링 노드에게 잘 되었는지 확인하는 것임. 
하지만 중복된 블록 해시 검사가 있기에 중복되는 함수 부분을 제거를 해줌.