### PR TITLE
Fix simTime to get getpeerinfo data

### DIFF
--- a/testlibs/xmlGenerator.py
+++ b/testlibs/xmlGenerator.py
@@ -39,7 +39,7 @@ def setup_multiple_node_xml(node_num, simultime, bool_, algorithm, difficulty):
         node_id = "client%d" % (i)
         node = ET.SubElement(shadow, "node", id=node_id)
         time = str(5)
-        argument = "%d.%d.0.1:11111 %d " % (i/256 + 1, i%256, (simultime-7))
+        argument = "%d.%d.0.1:11111 %d " % (i/256 + 1, i%256, (simultime-8))
         ET.SubElement(node,"application", plugin="client", time=time, arguments=argument)
 
     if bool_ == True:


### PR DESCRIPTION
xml 파일을 생성할 시, 마이너 노드가 kill 되는 시간을 1초 앞당김. 그렇지 않을 경우 마지막 rpc call인 getpeerinfo가 response 받지 못한채 시뮬레이션이 종료됨. 